### PR TITLE
fix button style issue and remove bug where empty note still adds

### DIFF
--- a/job-app-tracker/src/app/jobapplication/jobapplication.component.scss
+++ b/job-app-tracker/src/app/jobapplication/jobapplication.component.scss
@@ -23,11 +23,12 @@
         display: flex;
         align-items: center;
         justify-content: space-around;
+        flex-direction: column;
 
         div {
-            width: 95%;
+            width: 100%;
             height: 100%;
-
+            margin: 0.25em 0;
             button {
                 width: 100%;
                 height: 100%;

--- a/job-app-tracker/src/app/jobapplication/jobapplication.component.ts
+++ b/job-app-tracker/src/app/jobapplication/jobapplication.component.ts
@@ -31,7 +31,9 @@ export class JobapplicationComponent {
     this.jobapp.status = newStatus as ApplicationStatus
     this.isEditing = false
     this.jobapp.updatedOn = new Date()
-    this.jobapp.notes.push(noteInput)
+    if (noteInput.trim() !== "") {
+      this.jobapp.notes.push(noteInput)
+    }
   }
 
   cancelUpdate() {


### PR DESCRIPTION
 fixed the following bugs:

1. button layout overlaps when both "edit" and "generate rejection letter" buttons displayed
An empty note is added upon updating an existing job app even if a note field is left blank